### PR TITLE
fix/NO-TICKET hide WordShowcase card when no URL; remove placeholder …

### DIFF
--- a/website/common/crosslex/view/src/crosslex/module/content/LearnPageModules.ts
+++ b/website/common/crosslex/view/src/crosslex/module/content/LearnPageModules.ts
@@ -92,7 +92,7 @@ export type WordShowcaseModule = Module<
   'wordShowcase',
   {
     heading: Heading;
-    wordShowcaseUrl: string;
+    wordShowcaseUrl?: string;
   }
 >;
 

--- a/website/frontend/entities/src/UI/WordShowcase.tsx
+++ b/website/frontend/entities/src/UI/WordShowcase.tsx
@@ -4,7 +4,7 @@ import { Card } from '@whitelotus/front-shared';
 
 type WordShowcaseProps = {
   heading: Heading;
-  wordShowcaseUrl: string;
+  wordShowcaseUrl?: string;
   needClose?: boolean;
   onClose?: () => void;
   showContent?: boolean;

--- a/website/mock/data/src/learnPage/anspruch.ts
+++ b/website/mock/data/src/learnPage/anspruch.ts
@@ -98,7 +98,6 @@ export const anspruch: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/apfel.ts
+++ b/website/mock/data/src/learnPage/apfel.ts
@@ -79,7 +79,6 @@ export const apfel: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-apple-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/auto.ts
+++ b/website/mock/data/src/learnPage/auto.ts
@@ -87,7 +87,6 @@ export const auto: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-car-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/beantragen.ts
+++ b/website/mock/data/src/learnPage/beantragen.ts
@@ -98,7 +98,6 @@ export const beantragen: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/bescheinigung.ts
+++ b/website/mock/data/src/learnPage/bescheinigung.ts
@@ -99,7 +99,6 @@ export const bescheinigung: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/erfahrung.ts
+++ b/website/mock/data/src/learnPage/erfahrung.ts
@@ -110,7 +110,6 @@ export const erfahrung: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/formular.ts
+++ b/website/mock/data/src/learnPage/formular.ts
@@ -98,7 +98,6 @@ export const formular: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/frist.ts
+++ b/website/mock/data/src/learnPage/frist.ts
@@ -98,7 +98,6 @@ export const frist: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/genehmigung.ts
+++ b/website/mock/data/src/learnPage/genehmigung.ts
@@ -98,7 +98,6 @@ export const genehmigung: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/haus.ts
+++ b/website/mock/data/src/learnPage/haus.ts
@@ -87,7 +87,6 @@ export const haus: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-house-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/katze.ts
+++ b/website/mock/data/src/learnPage/katze.ts
@@ -79,7 +79,6 @@ export const katze: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-cat-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/nachweisen.ts
+++ b/website/mock/data/src/learnPage/nachweisen.ts
@@ -99,7 +99,6 @@ export const nachweisen: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/tisch.ts
+++ b/website/mock/data/src/learnPage/tisch.ts
@@ -87,7 +87,6 @@ export const tisch: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-table-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/uebertragen.ts
+++ b/website/mock/data/src/learnPage/uebertragen.ts
@@ -98,7 +98,6 @@ export const uebertragen: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/unterlagen.ts
+++ b/website/mock/data/src/learnPage/unterlagen.ts
@@ -98,7 +98,6 @@ export const unterlagen: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },

--- a/website/mock/data/src/learnPage/zustaendigkeit.ts
+++ b/website/mock/data/src/learnPage/zustaendigkeit.ts
@@ -99,7 +99,6 @@ export const zustaendigkeit: LearnPageContent = {
       {
         moduleType: 'wordShowcase',
         heading: { text: 'Word Showcase' },
-        wordShowcaseUrl: 'https://example.com/word-theater-video.mp4',
       },
     ],
   },


### PR DESCRIPTION
…URLs

Makes wordShowcaseUrl optional in the type and component so the card hides itself naturally when the field is absent. Removes example.com placeholder URLs from all mock word data.