### PR TITLE
fix/NO-TICKET render mnemonic text inline to keep bullet on same line

### DIFF
--- a/website/frontend/entities/src/UI/Mnemonics.tsx
+++ b/website/frontend/entities/src/UI/Mnemonics.tsx
@@ -29,7 +29,7 @@ export const Mnemonics: React.FC<MnemonicsProps> = ({
           <ul className="list-disc list-inside">
             {mnemonics.map((hook, index) => (
               <li key={index}>
-                <BodyText>{hook.content}</BodyText>
+                <BodyText as="span">{hook.content}</BodyText>
               </li>
             ))}
           </ul>

--- a/website/frontend/shared/src/UI/Text/BodyText.tsx
+++ b/website/frontend/shared/src/UI/Text/BodyText.tsx
@@ -3,16 +3,19 @@ import React from 'react';
 type BodyTextProps = {
   children: React.ReactNode;
   className?: string;
+  as?: 'p' | 'span';
 };
 
-const BodyText: React.FC<BodyTextProps> = ({ children, className = '' }) => {
-  return (
-    <p
-      className={`text-base sm:text-md md:text-lg lg:text-lg text-text mb-10 ${className}`}
-    >
-      {children}
-    </p>
-  );
-};
+const BodyText: React.FC<BodyTextProps> = ({
+  children,
+  className = '',
+  as: Tag = 'p',
+}) => (
+  <Tag
+    className={`text-base sm:text-md md:text-lg lg:text-lg text-text mb-10 ${className}`}
+  >
+    {children}
+  </Tag>
+);
 
 export { BodyText };


### PR DESCRIPTION
BodyText renders a <p> (block element) which pushes content below the bullet marker. Added an `as` prop to BodyText so it can render a <span> instead, and use it in the mnemonics list.