### PR TITLE
feat: add AlphaAnnouncement widget for test-user onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,39 @@ Before creating any new component:
 3. **Never duplicate** — if a component exists in a lower slice, use it
 4. **Never import upward** — pages import features/entities/shared; features import entities/shared; entities import shared only
 5. **When in doubt, ask** which slice a new component belongs to before creating it
+
+## Alpha Announcement Widget
+
+A one-time announcement widget that shows context to alpha test users based on their localStorage state.
+
+**User states:**
+- **New user** (no `crosslex:seen_build` in localStorage): full-page overlay blocks the app until the user clicks the CTA.
+- **Returning user on a new build** (`crosslex:seen_build` value ≠ `CURRENT_BUILD_ID`): dismissible card at bottom-right.
+- **Returning user, same build**: nothing renders.
+
+**Files:**
+```
+frontend/widgets/src/Crosslex/AlphaAnnouncement/
+├── changelog.ts          ← edit this for every new build
+├── AlphaAnnouncement.tsx ← orchestrator, reads localStorage
+├── NewUserOverlay.tsx    ← full-page overlay for first-time visitors
+└── ReturningUserCard.tsx ← card for returning visitors on a new build
+```
+
+**To cut a new build:**
+1. Open `changelog.ts`
+2. Update `CURRENT_BUILD_ID` to a new string, e.g. `'alpha-2026-05-11'`
+3. Add a matching entry to `CHANGELOG`:
+   ```ts
+   'alpha-2026-05-11': {
+     newUser: { heading: '...', body: '...', cta: "Let's go →" },
+     returningUser: {
+       heading: "You're back — something's new",
+       body: 'Here is what changed.',
+       changes: ['Added X', 'Fixed Y'],
+     },
+   },
+   ```
+4. Commit. No env vars, no Vite config changes needed.
+
+**localStorage key:** `crosslex:seen_build` — stores the last acknowledged build ID.

--- a/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/AlphaAnnouncement.tsx
+++ b/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/AlphaAnnouncement.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { CURRENT_BUILD_ID, CHANGELOG } from './changelog';
+import { NewUserOverlay } from './NewUserOverlay';
+import { ReturningUserCard } from './ReturningUserCard';
+
+const getSeenBuild = (): string | null => {
+  try {
+    return localStorage.getItem('crosslex:seen_build');
+  } catch {
+    return null;
+  }
+};
+
+const AlphaAnnouncement: React.FC = () => {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  const seenBuild = getSeenBuild();
+  if (seenBuild === CURRENT_BUILD_ID) return null;
+
+  const entry = CHANGELOG[CURRENT_BUILD_ID];
+  if (!entry) return null;
+
+  const onDismiss = () => setDismissed(true);
+
+  if (!seenBuild) {
+    return (
+      <NewUserOverlay
+        entry={entry}
+        buildId={CURRENT_BUILD_ID}
+        onDismiss={onDismiss}
+      />
+    );
+  }
+
+  return (
+    <ReturningUserCard
+      entry={entry}
+      buildId={CURRENT_BUILD_ID}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
+export { AlphaAnnouncement };

--- a/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/NewUserOverlay.tsx
+++ b/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/NewUserOverlay.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Card } from '@whitelotus/front-shared';
+import { ChangelogEntry } from './changelog';
+
+const STORAGE_KEY = 'crosslex:seen_build';
+const ctaButton =
+  'bg-brand border-2 border-brand rounded-md text-text-cta px-40 py-10 transition-colors duration-300';
+
+type Props = { entry: ChangelogEntry; buildId: string; onDismiss: () => void };
+
+const NewUserOverlay: React.FC<Props> = ({ entry, buildId, onDismiss }) => {
+  const handleCta = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, buildId);
+    } catch {}
+    onDismiss();
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 bg-dark flex items-center justify-center">
+      <div
+        className="mx-20 max-w-400 w-full"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Card heading={{ level: 'h1', text: entry.newUser.heading }}>
+          <p className="text-text mb-30">{entry.newUser.body}</p>
+          <div className="flex justify-center">
+            <button className={ctaButton} onClick={handleCta}>
+              {entry.newUser.cta}
+            </button>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export { NewUserOverlay };

--- a/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/ReturningUserCard.tsx
+++ b/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/ReturningUserCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Card } from '@whitelotus/front-shared';
+import { ChangelogEntry } from './changelog';
+
+const STORAGE_KEY = 'crosslex:seen_build';
+
+type Props = { entry: ChangelogEntry; buildId: string; onDismiss: () => void };
+
+const ReturningUserCard: React.FC<Props> = ({ entry, buildId, onDismiss }) => {
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, buildId);
+    } catch {}
+    onDismiss();
+  };
+
+  return (
+    <div className="fixed bottom-130 right-20 z-30 max-w-400 w-full">
+      <Card
+        heading={{ level: 'h2', text: entry.returningUser.heading }}
+        needClose
+        onClose={handleDismiss}
+      >
+        <p className="text-text mb-10">{entry.returningUser.body}</p>
+        {entry.returningUser.changes.length > 0 && (
+          <ul className="list-disc list-inside text-text space-y-10">
+            {entry.returningUser.changes.map((change, i) => (
+              <li key={i}>{change}</li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export { ReturningUserCard };

--- a/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/changelog.ts
+++ b/website/frontend/widgets/src/Crosslex/AlphaAnnouncement/changelog.ts
@@ -1,0 +1,21 @@
+export type ChangelogEntry = {
+  newUser: { heading: string; body: string; cta: string };
+  returningUser: { heading: string; body: string; changes: string[] };
+};
+
+export const CURRENT_BUILD_ID = 'alpha-2026-05-04';
+
+export const CHANGELOG: Record<string, ChangelogEntry> = {
+  'alpha-2026-05-04': {
+    newUser: {
+      heading: "You're testing Crosslex Alpha",
+      body: "Crosslex is a German vocabulary trainer for B1+ learners — built for adults navigating real life in Germany. This alpha has a small set of words for you to explore. Flip through them, read the context, and try the quiz. Your feedback shapes what we build next.",
+      cta: "Let's go →",
+    },
+    returningUser: {
+      heading: "You're back — something's new",
+      body: 'Thanks for returning to Crosslex.',
+      changes: [],
+    },
+  },
+};

--- a/website/frontend/widgets/src/index.ts
+++ b/website/frontend/widgets/src/index.ts
@@ -1,1 +1,2 @@
 export { LearnPage } from './Crosslex/LearnPage';
+export { AlphaAnnouncement } from './Crosslex/AlphaAnnouncement/AlphaAnnouncement';

--- a/website/sites/crosslex-react/package.json
+++ b/website/sites/crosslex-react/package.json
@@ -13,6 +13,7 @@
     "@whitelotus/front-features": "*",
     "@whitelotus/front-pages-react": "*",
     "@whitelotus/front-shared": "*",
+    "@whitelotus/front-widgets": "*",
     "@whitelotus/mock-test": "*",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/website/sites/crosslex-react/src/App.tsx
+++ b/website/sites/crosslex-react/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Palette,
 } from '@whitelotus/front-features';
 import { Card } from '@whitelotus/front-shared';
+import { AlphaAnnouncement } from '@whitelotus/front-widgets';
 
 const ctaButton =
   'bg-brand border-2 border-brand rounded-md text-text-cta px-40 py-10 transition-colors duration-300 disabled:opacity-40';
@@ -25,6 +26,7 @@ const App: React.FC = () => {
 
   return (
     <div className="pb-130 md:pb-0">
+      <AlphaAnnouncement />
       <LearnPageView key={key} content={content} />
 
       {/* Desktop nav */}

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6325,6 +6325,7 @@ __metadata:
     "@whitelotus/front-features": "npm:*"
     "@whitelotus/front-pages-react": "npm:*"
     "@whitelotus/front-shared": "npm:*"
+    "@whitelotus/front-widgets": "npm:*"
     "@whitelotus/mock-test": "npm:*"
     autoprefixer: "npm:10.4.15"
     postcss: "npm:^8.4.39"


### PR DESCRIPTION
Adds a self-contained widget that shows a full-page overlay to new visitors and a dismissible card to returning users on a new build. Build identity and all copy live in changelog.ts — update CURRENT_BUILD_ID there to release a new announcement. No env vars or backend required.