### PR TITLE
feat: add WordDefinitionQuestion entity with Storybook story

### DIFF
--- a/website/frontend/entities/src/UI/WordDefinitionQuestion.stories.tsx
+++ b/website/frontend/entities/src/UI/WordDefinitionQuestion.stories.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import {
+  WordDefinitionQuestion,
+  WordDefinitionQuestionData,
+} from './WordDefinitionQuestion';
+
+const EXERCISES: Record<string, WordDefinitionQuestionData> = {
+  erfahrung: {
+    word: 'Erfahrung',
+    article: 'die',
+    options: [
+      {
+        text: 'Knowledge or skill gained from doing, seeing, or feeling things.',
+        isCorrect: true,
+      },
+      {
+        text: 'An official document that proves something is true.',
+        isCorrect: false,
+      },
+      {
+        text: 'A period of time within which something must be done.',
+        isCorrect: false,
+      },
+      {
+        text: 'The authority or responsibility to deal with something.',
+        isCorrect: false,
+      },
+    ],
+  },
+  frist: {
+    word: 'Frist',
+    article: 'die',
+    options: [
+      {
+        text: 'A period of time within which something must be done.',
+        isCorrect: true,
+      },
+      {
+        text: 'Knowledge or skill gained from doing, seeing, or feeling things.',
+        isCorrect: false,
+      },
+      {
+        text: 'Official permission granted by an authority.',
+        isCorrect: false,
+      },
+      {
+        text: 'Papers or files required for an official process.',
+        isCorrect: false,
+      },
+    ],
+  },
+  beantragen: {
+    word: 'beantragen',
+    article: null,
+    options: [
+      {
+        text: 'To formally apply for something from an authority.',
+        isCorrect: true,
+      },
+      {
+        text: 'To prove or demonstrate something with evidence.',
+        isCorrect: false,
+      },
+      {
+        text: 'To transfer data or responsibility to another party.',
+        isCorrect: false,
+      },
+      {
+        text: 'A period of time within which something must be done.',
+        isCorrect: false,
+      },
+    ],
+  },
+};
+
+type WrapperProps = {
+  word: string;
+};
+
+const Wrapper: React.FC<WrapperProps> = ({ word }) => (
+  <div className="max-w-4xl mx-auto p-20">
+    <WordDefinitionQuestion
+      heading={{ level: 'h2', text: 'What does this word mean?' }}
+      wordDefinitionQuestion={EXERCISES[word]}
+    />
+  </div>
+);
+
+export default {
+  title: 'Entities/WordDefinitionQuestion',
+  component: Wrapper,
+  argTypes: {
+    word: {
+      control: { type: 'select' },
+      options: Object.keys(EXERCISES),
+      description: 'Select a word to display the corresponding exercise.',
+    },
+  },
+} as Meta<typeof Wrapper>;
+
+const Template: StoryFn<typeof Wrapper> = (args) => <Wrapper {...args} />;
+
+export const Default: StoryObj<typeof Wrapper> = Template.bind({});
+Default.args = {
+  word: 'erfahrung',
+};

--- a/website/frontend/entities/src/UI/WordDefinitionQuestion.tsx
+++ b/website/frontend/entities/src/UI/WordDefinitionQuestion.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { Heading } from '@whitelotus/common-crosslex-view';
+
+type Article = 'der' | 'die' | 'das' | null;
+import { BodyText, Card, CtaText } from '@whitelotus/front-shared';
+
+type Option = {
+  text: string;
+  isCorrect: boolean;
+};
+
+export type WordDefinitionQuestionData = {
+  word: string;
+  article?: Article;
+  options: Option[];
+};
+
+type Props = {
+  heading: Heading;
+  wordDefinitionQuestion: WordDefinitionQuestionData;
+  needClose?: boolean;
+  onClose?: () => void;
+  showContent?: boolean;
+};
+
+const WordDefinitionQuestion: React.FC<Props> = ({
+  heading,
+  wordDefinitionQuestion,
+  needClose,
+  onClose,
+  showContent = true,
+}) => {
+  const [optionStates, setOptionStates] = useState(
+    wordDefinitionQuestion.options.map(() => ({
+      isClicked: false,
+      isCorrect: false,
+    })),
+  );
+
+  const handleOptionClick = (index: number) => {
+    setOptionStates((prev) =>
+      prev.map((state, i) =>
+        i === index
+          ? {
+              isClicked: true,
+              isCorrect: wordDefinitionQuestion.options[index].isCorrect,
+            }
+          : state,
+      ),
+    );
+  };
+
+  const { word, article } = wordDefinitionQuestion;
+  const displayWord = article ? `${article} ${word}` : word;
+
+  return (
+    <Card
+      heading={heading}
+      needClose={needClose}
+      onClose={onClose}
+      showContent={showContent}
+    >
+      <div className="flex justify-center mb-30">
+        <BodyText as="span" className="text-brand font-bold text-lg md:text-xl">
+          {displayWord}
+        </BodyText>
+      </div>
+      <div>
+        {wordDefinitionQuestion.options.map((option, index) => (
+          <div
+            key={index}
+            className={`cursor-pointer border-2 rounded-lg px-40 py-10 mb-10 transition-colors duration-300 border-color7 ${
+              optionStates[index].isClicked
+                ? optionStates[index].isCorrect
+                  ? 'border-color1 bg-color2 text-white animate-bounce'
+                  : 'border-color3 bg-color4 text-white animate-vibrate'
+                : 'bg-gradient-brand hover:bg-none hover:bg-brand-2'
+            }`}
+            onClick={() => handleOptionClick(index)}
+          >
+            <CtaText>{option.text}</CtaText>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+export { WordDefinitionQuestion };

--- a/website/frontend/entities/src/UI/index.ts
+++ b/website/frontend/entities/src/UI/index.ts
@@ -7,4 +7,6 @@ export { SimilarWords } from './SimilarWords';
 export { WordContext } from './WordContext';
 export { WordIntro } from './WordIntro';
 export { WordMeaning } from './WordMeaning';
+export { WordDefinitionQuestion } from './WordDefinitionQuestion';
+export type { WordDefinitionQuestionData } from './WordDefinitionQuestion';
 export { WordShowcase } from './WordShowcase';

--- a/website/frontend/entities/src/index.ts
+++ b/website/frontend/entities/src/index.ts
@@ -7,6 +7,7 @@ export {
   WordContext,
   WordIntro,
   WordMeaning,
+  WordDefinitionQuestion,
   WordShowcase,
 } from './UI';
-export type { ContextBlankQuestionData } from './UI';
+export type { ContextBlankQuestionData, WordDefinitionQuestionData } from './UI';


### PR DESCRIPTION
Exercise type 3 — word shown, pick correct definition from 4 options. Accepts all options as props; distractor selection deferred to session loop. Story covers erfahrung, frist, beantragen with inline mock definitions.