### PR TITLE
feat: Progress module for backend/api/crosslex (Phase 4)

### DIFF
--- a/website/backend/api/crosslex/DECISIONS.md
+++ b/website/backend/api/crosslex/DECISIONS.md
@@ -1,0 +1,318 @@
+# Decisions
+
+Architectural/design decisions for `backend/api/crosslex` and the reasoning
+behind them — not a changelog, not a process log. Process/branching/workflow
+lives in `AGENTS.md`; this is for things a future reader (including future
+you) would otherwise have to re-derive from scratch or, worse, get wrong by
+assuming the obvious-looking alternative was never considered.
+
+Each entry: **Decision**, **Why**, and **Alternatives considered** where a
+real one existed. Newest section at the bottom; append, don't rewrite
+history — if a decision gets reversed later, add a new entry saying so
+rather than editing the old one away.
+
+---
+
+## Auth (Phase 3)
+
+### D1 — httpOnly cookie + relay, not a JS-readable cookie
+**Decision:** Refresh token travels only in an `httpOnly` cookie; the SPA
+never reads it directly.
+**Why:** The refresh token is the long-lived, high-value credential — an
+httpOnly cookie is unreadable by any JS running on the page, so XSS cannot
+exfiltrate it. This is the strongest part of the security story and the one
+most likely to come up in a fintech interview (XSS vs. CSRF, and which
+mitigation addresses which). Full reasoning recorded in
+`2026-07-18-phase-3-instructions.md`.
+
+### RS256, not HS256
+**Decision:** JWTs are signed with RS256 (asymmetric), not HS256
+(symmetric).
+**Why:** A symmetric secret has to be shared with anything that verifies a
+token — awkward and risky the moment there's more than one verifier (e.g. a
+future split-out service, Phase 7's D2). RS256 lets the private key stay in
+exactly one place (the signer) while the public key can be handed out freely
+for verification.
+
+### argon2id for passwords, SHA-256 for refresh tokens — not the same algorithm for both
+**Decision:** Passwords are hashed with argon2id (slow, memory-hard).
+Refresh tokens are hashed with SHA-256 (fast) before storage.
+**Why:** These defend against different things. Passwords are low-entropy
+secrets a human chose — slow hashing is the actual defense against
+brute-force. Refresh tokens are 32 random bytes — already unguessable, so a
+fast hash costs nothing in security and avoids paying argon2's real CPU cost
+on every single refresh call.
+
+### Refresh rotation via atomic conditional UPDATE, not read-then-write
+**Decision:** Rotation does `updateMany({ where: { id, revokedAt: null },
+data: { revokedAt: now } })` and branches on the returned count, rather than
+reading the row, checking `revokedAt` in application code, then writing.
+**Why:** The `revokedAt: null` check has to live in the `WHERE` clause, not
+a separate read, or two concurrent requests presenting the same token could
+both read "not yet revoked" before either writes — a classic check-then-act
+race. `count === 0` on the update is the actual reuse signal.
+
+### Login always calls argon2.verify(), even for a nonexistent user
+**Decision:** `login()` verifies against a precomputed dummy hash when no
+user is found, rather than returning early.
+**Why:** No-account-enumeration isn't just about the error message being
+identical for "wrong password" and "unknown email" — it's also about
+*timing*. Skipping the hash for an unknown email would make that path
+measurably faster, leaking which case occurred even with an identical error
+string.
+
+### Cookie-setting lives in the resolver via `@Context()`, not `@Res()`
+**Decision:** `signup`/`login`/`refresh`/`logout` all read `res` off
+`@Context()`, not a `@Res({ passthrough: true })` parameter.
+**Why:** Not style — `@Res()` is fundamentally broken in this stack.
+`@nestjs/graphql`'s `GqlParamsFactory` only understands ROOT/ARGS/CONTEXT/
+INFO; it has no case for the core `@Res()`/`@Req()` decorators. Their
+`RouteParamtypes` numeric values happen to collide with `GqlParamtype`'s
+(`RESPONSE === CONTEXT === 1`), so `@Res()` silently resolves to the whole
+GraphQL context object instead of the response — compiles fine, throws
+`res.cookie is not a function` the instant it's actually called. Found by
+the e2e suite, not by any build or boot check.
+
+### `GraphQLModule.forRoot()` needs an explicit `context` factory
+**Decision:** `context: ({ req, res }) => ({ req, res })` is set explicitly
+in `app.module.ts`.
+**Why:** `@nestjs/apollo`'s default context only forwards `req` — `res` is
+silently absent otherwise, which was the second half of the bug above (even
+after fixing `@Res()` → `@Context()`, `res` was still `undefined` until this
+was added).
+
+### `TokenService` stays inside `AuthModule` — doesn't get its own module
+**Decision:** `TokenService` is a provider in `AuthModule`, not exported.
+**Why:** A NestJS module should be a feature/domain boundary, not a
+per-class wrapper. The rule that actually matters: does more than one
+otherwise-independent feature need this? `PrismaService` does (hence
+`PrismaModule`, imported by `AuthModule`) — `TokenService` doesn't, nothing
+outside the auth flow issues/rotates/revokes tokens. Not being exported is
+deliberate: it keeps `TokenService` genuinely private to the module, not
+just conventionally private.
+
+### AWS Secrets Manager: fetch by ARN, one raw PEM per secret
+**Decision:** `JWT_KEY_SOURCE=secrets-manager` calls `GetSecretValueCommand`
+with the configured `SecretId` (ARN or name), returns `SecretString`
+directly — no JSON wrapping, no caching layer inside the provider itself.
+**Why:** ARN over name lets IAM policies scope to the exact resource
+(Secrets Manager appends a random suffix to every ARN, so name-based policy
+matching is fragile). No caching here because the callers already handle
+it correctly — `JwtModule.registerAsync`'s factory runs once at boot,
+`JwtStrategy` already caches its own call via a cached promise (see below).
+
+### `JwtStrategy` caches the *promise*, not the resolved key
+**Decision:** `secretOrKeyProvider` stores `Promise<string>` in an instance
+field, assigned synchronously (no `await` between the check and the
+assignment), with the promise reset to `null` on rejection.
+**Why:** Caching the resolved value naively (check-if-null, then `await`,
+then assign) leaves a window where concurrent requests during the first
+resolution all see the cache as empty and each trigger a redundant fetch —
+harmless for a local file read, a real cost once this hits Secrets Manager
+over the network. Resetting on rejection stops one transient failure from
+poisoning every future request until a restart.
+
+---
+
+## Progress / schema (Phase 4)
+
+### `Word.id` is a surrogate UUID — `wordKey` is not the primary key
+**Decision:** `Word` has its own generated `id`; `wordKey` is a plain,
+non-unique, indexed column.
+**Why:** German has real homographs — "die Mutter" means both "mother" and
+"nut" (hardware), same spelling, same article, same part of speech, only
+the meaning differs. No composite of grammatical columns (`wordKey` +
+`article`, even `wordKey` + `article` + `partOfSpeech`) can reliably
+disambiguate every case, because a homograph's whole definition is that its
+*form* is identical — only meaning differs, and meaning isn't a column you
+can build a uniqueness constraint on. The surrogate id sidesteps the
+problem entirely instead of chasing an unreachable "right" natural key.
+**Alternatives considered:** `wordKey` as the primary key (rejected — can't
+represent two words sharing a spelling); composite unique on grammatical
+metadata (rejected — `Mutter`/`Mutter` proves no finite set of columns
+reliably works).
+
+### `Word` stays content-free
+**Decision:** `Word` holds `id`/`wordKey`/`createdAt` only — no meaning,
+theme, or exercise content.
+**Why:** `mock/data/` is the sole authority on what a word means; nothing
+server-side currently needs to know. Duplicating content into `Word` would
+recreate a two-sources-of-truth problem for no functional gain today.
+Revisit only if/when word content genuinely needs to be served from the API
+(a separate, larger decision — see "Deferred" below).
+
+### `WordProgress`: one composite unique index, not two
+**Decision:** `@@unique([userId, wordId])`, no separate `@@index([userId])`.
+**Why:** A composite unique index is a real b-tree index under the hood,
+and Postgres supports leftmost-prefix matching — a query filtering on
+`userId` alone (exactly what "give me this user's whole progress" needs,
+per the scheduling algorithm's actual access pattern in
+`docs/session-loop.md`) is already served by it. A second index would be
+redundant.
+
+### `ExerciseEvent` is indexed `(userId, wordId)`, not `(userId, occurredAt)`
+**Decision:** The event log's index matches "this user's history for this
+word," not a time-ordered activity feed.
+**Why:** Index for the query you actually have. Nothing in the documented
+product surface needs a chronological feed; the real, concrete need (per
+the scheduling algorithm, and later the dashboard discussion) is per-word
+history. Revisit if a genuinely time-windowed query shows up — adding an
+index later costs nothing extra (no backfill, unlike a key-structure
+change), so there's no reason to pre-empt it.
+
+### `ExerciseEvent` denormalizes `wordId`/`exerciseType` even though `exerciseId` exists
+**Decision:** `ExerciseEvent` keeps its own `wordId` and `exerciseType`
+columns alongside the `exerciseId` FK, rather than relying purely on a join
+through `Exercise`.
+**Why:** `exerciseType` is a snapshot of what the exercise *was* at attempt
+time — this table is an append-only audit log, and event logs snapshot
+relevant facts rather than depending on a live join to data that might
+later be edited or reclassified. `wordId` is kept mainly so the
+`(userId, wordId)` index doesn't require joining through `Exercise` first.
+
+### `Exercise.content` is `Json` + a type discriminator, not per-type tables
+**Decision:** One `Exercise` table, `exerciseType: String`,
+`content: Json`, rather than a table per exercise kind (or a base +
+extension-table split).
+**Why:** The four exercise kinds genuinely differ in shape (multiple-choice
+variants vs. `typeTheWord`'s free-text recall), but this is
+product-iteration-speed content — it's already changed once
+(alpha-2026-05-05-session-polish) — and a schema requiring a migration for
+every new exercise type or reshaped field is the wrong tradeoff for content
+that changes at product-decision speed, not database-integrity speed. The
+real cost: Postgres can't validate `content`'s shape, so that check moves to
+the application boundary (a discriminated union validated before write).
+
+### `userId` is never a GraphQL argument — always from `@CurrentUser()`
+**Decision:** No mutation or query in `ProgressModule` accepts `userId` as
+input. `JwtAuthGuard` is applied at the resolver-class level (not per
+method), so any future method is covered automatically.
+**Why:** This is the entire authorization model in one rule. The guard
+proves *who you are* (authentication); the service's
+`where userId = claim.sub` proves *what you may touch* (authorization) —
+and the second only holds if the client can never supply `userId` itself.
+
+### `wordId`/`exerciseType` are derived server-side from the `Exercise` row, not sent by the client
+**Decision:** `recordExerciseResult`'s input is just `{ exerciseId,
+correct }`. The service looks up `Exercise` to get `wordId`/`exerciseType`,
+rather than trusting the client to also assert them.
+**Why:** Same principle as the `userId` rule, one level down: don't let the
+client tell the server something the server can and should derive itself
+from data it already trusts. Requiring the client to send `wordId`
+separately risks it disagreeing with the `exerciseId`'s real word — a
+crafted or stale input, or just a bug — which would need its own
+validation code to catch. Deriving it eliminates the whole problem class.
+
+### No update/delete mutation exists for `ExerciseEvent`
+**Decision:** The append-only invariant (mirroring `crosslex:exercise_log`'s
+client-side rule from `AGENTS.md`) is enforced by simply never exposing a
+mutation capable of violating it.
+**Why:** The simplest possible enforcement of an invariant is not building
+the capability to break it, rather than adding logic to prevent misuse of a
+capability that didn't need to exist.
+
+### Rejected: pruning `ExerciseEvent` to the last N rows per (user, word)
+**Decision:** Explicitly rejected — the table keeps full history,
+unbounded.
+**Why:** The problem it would solve (efficient "last N" retrieval) is
+already solved by the existing index — pruning doesn't make that query
+faster. Storage isn't a real constraint at any realistic scale (tens of
+thousands of rows per active user per year, and Postgres comfortably
+indexes hundreds of millions). Pruning would destroy the audit trail and
+any future analytics value, and adds a new failure surface (a delete path
+that has to correctly identify only the right rows) to a table that's
+currently trivial to reason about specifically because nothing in it can
+ever be corrupted by a bad update/delete — because none exist.
+
+### Deferred: dashboard rollup table / Redis cache
+**Decision:** Not built now. If real usage ever makes trend-style dashboard
+queries slow, the lever is a `(userId, occurredAt)` index first (cheap,
+no backfill cost — unlike the key-structure decisions above, this can
+always wait), and only a real precomputed rollup table or cache if that's
+still not enough.
+**Why:** `WordProgress` is a point-in-time snapshot by design — it
+structurally cannot answer "what was my accuracy 3 weeks ago," only
+`ExerciseEvent`'s raw log can. That's a known, accepted gap, not an
+oversight — no dashboard feature is scoped yet, and solving its performance
+before it exists is premature.
+
+---
+
+## Product scope (cross-cutting)
+
+### Online-required, offline as a later opt-in feature — not offline-first
+**Decision:** The backend assumes connectivity; a "keep words offline"
+feature is explicitly deferred, not designed in from day one.
+**Why:** Matches how most real products in this category actually sequence
+it (Duolingo: online-first, offline download bolted on later, not built in
+originally) — but worth remembering this doesn't by itself change where
+word *content* lives. Bundling static content into the JS build is fully
+compatible with an online-required app; those are two independent
+decisions.
+
+### Word content stays static/bundled — full DB migration deferred
+**Decision:** `mock/data/` remains the source of truth for word content.
+Moving it into Postgres (with a real content-authoring/seeding story) is a
+separate, larger initiative, not something to fold into Progress module
+work.
+**Why:** Nothing currently needs the API to serve word content — the
+`Word` table exists purely for referential integrity (see above). Scope
+creep risk was real: this came up while designing a schema for progress
+*tracking*, which doesn't require content modeling at all.
+
+### Frontend auth integration deferred
+**Decision:** No login/signup UI built yet.
+**Why:** Not required for interview-prep depth — the backend work is
+demonstrable and tested via GraphQL/supertest without a UI. Real product
+work, but on a different track than what this build is currently
+optimizing for.
+
+### AWS deploy (Phase 5) deferred; Phase 4/6/7 rescoped around it
+**Decision:** Phase 5 (VPC/RDS/RDS Proxy/Secrets Manager/Lambda) is
+explicitly out of scope for the current interview-prep timeline. Phase 6's
+cross-subdomain cookie work is rescoped to run locally via
+`app.crosslex.local`/`api.crosslex.local` instead of real deployed
+subdomains; Phase 7's Content module ships inline with the D2
+service-split decision left as written reasoning rather than a build.
+**Why:** Phase 5 is a new vendor and a new category of problem (cloud
+infra debugging is far less predictable than application code), and
+nothing in the target interview is AWS-specific. The Secrets Manager
+*code path* was still implemented on request, ahead of when it's needed —
+that doesn't change the scoping decision, it was just cheap to do while the
+relevant file was already open.
+
+---
+
+## Testing conventions
+
+### `backend/api/crosslex` uses NestJS's own spec-naming convention, not the monorepo default
+**Decision:** Unit tests are colocated `*.spec.ts`; e2e tests live in
+`test/` as `*.e2e-spec.ts`. The monorepo's shared `jest.config.base.js`
+default (`*.test.ts`) is not used here.
+**Why:** This package generates its own spec files via `nest g`, which
+default to Nest's convention — fighting that on every scaffold isn't worth
+it for one package's internal consistency. Each jest project is scoped by
+directory (`src/` vs `test/`), not a suffix-ignore pattern, since both
+families now share the `*.spec.ts` root.
+
+### Unit tests mock Prisma entirely; e2e tests hit a real, dedicated Postgres `test` schema
+**Decision:** Two separate jest projects (`unit`, `e2e`). Unit tests never
+touch a database. E2e tests run the real app against a `test` schema on
+the same local Postgres container as dev, never the dev schema itself.
+**Why:** Mocked unit tests are fast and can't be flaky on infra, but can't
+catch a forgotten `WHERE userId = ...` — only a real database enforces
+real filtering. E2e tests prove the real thing works, including the parts
+a mock can't (cookie attributes, guard/JWT chain, actual FK constraints).
+
+### E2e spec files must run serially (`--runInBand`), not in parallel workers
+**Decision:** `test:e2e` passes `--runInBand`. A shared `resetDatabase()`
+helper (`test/reset-database.ts`) is used by every e2e spec's `beforeEach`,
+not a per-file copy of the cleanup list.
+**Why:** Jest parallelizes different spec *files* into separate worker
+processes by default. All e2e specs share one real, mutable Postgres
+schema (not one per worker) — so with more than one e2e file, one file's
+`beforeEach` can wipe rows out from under another file's in-flight test.
+Invisible with a single e2e file; surfaced immediately the moment a second
+one (`progress.e2e-spec.ts`) was added. A shared reset helper additionally
+prevents per-file cleanup lists from silently drifting out of sync as new
+tables get added — the bug that caused this in the first place.

--- a/website/backend/api/crosslex/package.json
+++ b/website/backend/api/crosslex/package.json
@@ -14,7 +14,7 @@
     "build": "nest build",
     "start": "node dist/main.js",
     "test": "jest --selectProjects unit",
-    "test:e2e": "yarn migrate:test-db && jest --selectProjects e2e",
+    "test:e2e": "yarn migrate:test-db && jest --selectProjects e2e --runInBand",
     "test:ci": "yarn migrate:test-db && jest --ci --coverage"
   },
   "dependencies": {
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^11",
+    "@nestjs/schematics": "^11.1.0",
     "@nestjs/testing": "^11.1.0",
     "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.6",

--- a/website/backend/api/crosslex/prisma/migrations/20260803163137_progress_tables/migration.sql
+++ b/website/backend/api/crosslex/prisma/migrations/20260803163137_progress_tables/migration.sql
@@ -1,0 +1,53 @@
+-- CreateTable
+CREATE TABLE "Word" (
+    "id" TEXT NOT NULL,
+    "wordKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Word_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WordProgress" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "wordId" TEXT NOT NULL,
+    "seenCount" INTEGER NOT NULL DEFAULT 0,
+    "correctCount" INTEGER NOT NULL DEFAULT 0,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WordProgress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ExerciseEvent" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "wordId" TEXT NOT NULL,
+    "exerciseType" TEXT NOT NULL,
+    "correct" BOOLEAN NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ExerciseEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Word_wordKey_idx" ON "Word"("wordKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WordProgress_userId_wordId_key" ON "WordProgress"("userId", "wordId");
+
+-- CreateIndex
+CREATE INDEX "ExerciseEvent_userId_wordId_idx" ON "ExerciseEvent"("userId", "wordId");
+
+-- AddForeignKey
+ALTER TABLE "WordProgress" ADD CONSTRAINT "WordProgress_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WordProgress" ADD CONSTRAINT "WordProgress_wordId_fkey" FOREIGN KEY ("wordId") REFERENCES "Word"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExerciseEvent" ADD CONSTRAINT "ExerciseEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExerciseEvent" ADD CONSTRAINT "ExerciseEvent_wordId_fkey" FOREIGN KEY ("wordId") REFERENCES "Word"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/website/backend/api/crosslex/prisma/migrations/20260803171429_exercise_content/migration.sql
+++ b/website/backend/api/crosslex/prisma/migrations/20260803171429_exercise_content/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - Added the required column `exerciseId` to the `ExerciseEvent` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ExerciseEvent" ADD COLUMN     "exerciseId" TEXT NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Exercise" (
+    "id" TEXT NOT NULL,
+    "wordId" TEXT NOT NULL,
+    "exerciseType" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Exercise_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Exercise_wordId_idx" ON "Exercise"("wordId");
+
+-- AddForeignKey
+ALTER TABLE "Exercise" ADD CONSTRAINT "Exercise_wordId_fkey" FOREIGN KEY ("wordId") REFERENCES "Word"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExerciseEvent" ADD CONSTRAINT "ExerciseEvent_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/website/backend/api/crosslex/prisma/schema.prisma
+++ b/website/backend/api/crosslex/prisma/schema.prisma
@@ -19,7 +19,53 @@ model User {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  refreshTokens RefreshToken[]
+  refreshTokens  RefreshToken[]
+  wordProgress   WordProgress[]
+  exerciseEvents ExerciseEvent[]
+}
+
+// Deliberately bare: no meaning/theme/exercise content lives here. mock/data
+// stays the sole authority on what a word actually means — this table only
+// exists so WordProgress/ExerciseEvent have something real to foreign-key
+// against. wordKey is NOT unique and is NOT the primary key: German has
+// real homographs (e.g. "die Mutter" = mother, "die Mutter" = nut) that can
+// share identical spelling, article, AND part of speech — no natural
+// composite key reliably separates every case, since only the meaning
+// differs. The surrogate id is the one thing guaranteed unique; wordKey is
+// just an indexed lookup column, deliberately allowed to repeat.
+model Word {
+  id        String   @id @default(uuid())
+  wordKey   String
+  createdAt DateTime @default(now())
+
+  wordProgress   WordProgress[]
+  exerciseEvents ExerciseEvent[]
+  exercises      Exercise[]
+
+  @@index([wordKey])
+}
+
+// One row per exercise instance that exists for a word — content, not
+// per-user state (mirrors the Word/WordProgress split). `content` is
+// deliberately untyped at the DB level: the four exercise kinds
+// (meaningGuess/contextBlank/wordDefinition/typeTheWord, per
+// docs/session-loop.md) have genuinely different shapes, and this is
+// product-iteration-speed content, not transactional data — a new exercise
+// type or a reshaped existing one shouldn't require a migration. The
+// tradeoff: Postgres can't validate `content`'s shape, so that check has to
+// happen at the application boundary (e.g. a Zod discriminated union keyed
+// on exerciseType) before anything gets written.
+model Exercise {
+  id           String   @id @default(uuid())
+  wordId       String
+  word         Word     @relation(fields: [wordId], references: [id])
+  exerciseType String
+  content      Json
+  createdAt    DateTime @default(now())
+
+  exerciseEvents ExerciseEvent[]
+
+  @@index([wordId])
 }
 
 model RefreshToken {
@@ -34,4 +80,54 @@ model RefreshToken {
 
   @@index([userId])
   @@index([familyId])
+}
+
+// Mirrors crosslex:words_seen from docs/session-loop.md — the scheduling
+// algorithm's per-word cache (count, accuracy, lastSeen), synced server-side
+// for cross-device continuity. The unique constraint is what makes syncing
+// idempotent: recording progress for (user, word) always finds the same
+// row rather than creating duplicates. No separate index on userId alone
+// is needed — a composite unique index already serves leftmost-prefix
+// lookups ("all of this user's progress"), which is the only query the
+// algorithm actually makes; nothing queries "who else has seen this word."
+model WordProgress {
+  id           String   @id @default(uuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id])
+  wordId       String
+  word         Word     @relation(fields: [wordId], references: [id])
+  seenCount    Int      @default(0)
+  correctCount Int      @default(0)
+  lastSeenAt   DateTime @updatedAt
+
+  @@unique([userId, wordId])
+}
+
+// Mirrors crosslex:exercise_log — append-only by convention (AGENTS.md's
+// invariant carries over server-side): no update/delete mutation should
+// ever be exposed for this table. Indexed on (userId, wordId), not
+// (userId, occurredAt) — the real query need is "this user's history for
+// this word" (e.g. to recompute WordProgress from raw events), not a
+// time-ordered activity feed, which nothing in the product currently needs.
+//
+// wordId and exerciseType are intentionally denormalized, not leftover
+// duplication now that exerciseId exists: exerciseType is a snapshot of
+// what the exercise *was* at attempt time, so this append-only log stays
+// historically accurate even if an Exercise's content is later edited or
+// reclassified — that's the standard event-log reason to snapshot rather
+// than rely purely on a live join. wordId is kept mainly so the
+// (userId, wordId) index doesn't require joining through Exercise first.
+model ExerciseEvent {
+  id           String   @id @default(uuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id])
+  wordId       String
+  word         Word     @relation(fields: [wordId], references: [id])
+  exerciseId   String
+  exercise     Exercise @relation(fields: [exerciseId], references: [id])
+  exerciseType String
+  correct      Boolean
+  occurredAt   DateTime @default(now())
+
+  @@index([userId, wordId])
 }

--- a/website/backend/api/crosslex/schema.gql
+++ b/website/backend/api/crosslex/schema.gql
@@ -6,6 +6,11 @@ type AuthPayload {
   accessToken: String!
 }
 
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type Health {
   status: String!
   timestamp: String!
@@ -19,15 +24,31 @@ input LoginInput {
 type Mutation {
   login(input: LoginInput!): AuthPayload!
   logout: Boolean!
+  recordExerciseResult(input: RecordExerciseResultInput!): WordProgress!
   refresh: AuthPayload!
   signup(input: SignupInput!): AuthPayload!
 }
 
 type Query {
   health: Health!
+  myProgress: [WordProgress!]!
+}
+
+input RecordExerciseResultInput {
+  correct: Boolean!
+  exerciseId: String!
 }
 
 input SignupInput {
   email: String!
   password: String!
+}
+
+type WordProgress {
+  correctCount: Int!
+  id: String!
+  lastSeenAt: DateTime!
+  seenCount: Int!
+  wordId: String!
+  wordKey: String!
 }

--- a/website/backend/api/crosslex/src/app.module.ts
+++ b/website/backend/api/crosslex/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
+import { ProgressModule } from './progress/progress.module';
 
 const REQUIRED_ENV_VARS = ['DATABASE_URL', 'JWT_KEY_SOURCE'] as const;
 
@@ -45,6 +46,7 @@ const REQUIRED_ENV_VARS = ['DATABASE_URL', 'JWT_KEY_SOURCE'] as const;
     }),
     AuthModule,
     HealthModule,
+    ProgressModule,
   ],
 })
 export class AppModule {}

--- a/website/backend/api/crosslex/src/progress/dto/record-exercise-result.input.ts
+++ b/website/backend/api/crosslex/src/progress/dto/record-exercise-result.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsUUID } from 'class-validator';
+
+@InputType()
+export class RecordExerciseResultInput {
+  @Field()
+  @IsUUID()
+  exerciseId: string;
+
+  @Field()
+  @IsBoolean()
+  correct: boolean;
+}

--- a/website/backend/api/crosslex/src/progress/models/word-progress.model.ts
+++ b/website/backend/api/crosslex/src/progress/models/word-progress.model.ts
@@ -1,0 +1,22 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class WordProgress {
+  @Field()
+  id: string;
+
+  @Field()
+  wordId: string;
+
+  @Field()
+  wordKey: string;
+
+  @Field(() => Int)
+  seenCount: number;
+
+  @Field(() => Int)
+  correctCount: number;
+
+  @Field()
+  lastSeenAt: Date;
+}

--- a/website/backend/api/crosslex/src/progress/progress.module.ts
+++ b/website/backend/api/crosslex/src/progress/progress.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProgressService } from './progress.service';
+import { ProgressResolver } from './progress.resolver';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ProgressService, ProgressResolver],
+})
+export class ProgressModule {}

--- a/website/backend/api/crosslex/src/progress/progress.resolver.spec.ts
+++ b/website/backend/api/crosslex/src/progress/progress.resolver.spec.ts
@@ -1,0 +1,56 @@
+import { ProgressResolver } from './progress.resolver';
+import { ProgressService } from './progress.service';
+import { WordProgress } from './models/word-progress.model';
+
+describe('ProgressResolver', () => {
+  let progressService: {
+    recordExerciseResult: jest.Mock;
+    getMyProgress: jest.Mock;
+  };
+  let resolver: ProgressResolver;
+
+  const FAKE_WORD_PROGRESS: WordProgress = {
+    id: 'wp-1',
+    wordId: 'word-1',
+    wordKey: 'auto',
+    seenCount: 1,
+    correctCount: 1,
+    lastSeenAt: new Date(),
+  };
+
+  beforeEach(() => {
+    progressService = {
+      recordExerciseResult: jest.fn().mockResolvedValue(FAKE_WORD_PROGRESS),
+      getMyProgress: jest.fn().mockResolvedValue([FAKE_WORD_PROGRESS]),
+    };
+
+    resolver = new ProgressResolver(
+      progressService as unknown as ProgressService,
+    );
+  });
+
+  describe('recordExerciseResult', () => {
+    it('forwards the callers userId from @CurrentUser(), never a client-supplied value, plus the input', async () => {
+      const input = { exerciseId: 'exercise-1', correct: true };
+
+      const result = await resolver.recordExerciseResult(input, {
+        userId: 'user-1',
+      });
+
+      expect(progressService.recordExerciseResult).toHaveBeenCalledWith(
+        'user-1',
+        input,
+      );
+      expect(result).toBe(FAKE_WORD_PROGRESS);
+    });
+  });
+
+  describe('myProgress', () => {
+    it('forwards the callers userId from @CurrentUser() with no other arguments', async () => {
+      const result = await resolver.myProgress({ userId: 'user-1' });
+
+      expect(progressService.getMyProgress).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual([FAKE_WORD_PROGRESS]);
+    });
+  });
+});

--- a/website/backend/api/crosslex/src/progress/progress.resolver.ts
+++ b/website/backend/api/crosslex/src/progress/progress.resolver.ts
@@ -1,0 +1,28 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ProgressService } from './progress.service';
+import { RecordExerciseResultInput } from './dto/record-exercise-result.input';
+import { WordProgress } from './models/word-progress.model';
+
+@UseGuards(JwtAuthGuard)
+@Resolver()
+export class ProgressResolver {
+  constructor(private readonly progressService: ProgressService) {}
+
+  @Mutation(() => WordProgress)
+  async recordExerciseResult(
+    @Args('input') input: RecordExerciseResultInput,
+    @CurrentUser() user: { userId: string },
+  ): Promise<WordProgress> {
+    return this.progressService.recordExerciseResult(user.userId, input);
+  }
+
+  @Query(() => [WordProgress])
+  async myProgress(
+    @CurrentUser() user: { userId: string },
+  ): Promise<WordProgress[]> {
+    return this.progressService.getMyProgress(user.userId);
+  }
+}

--- a/website/backend/api/crosslex/src/progress/progress.service.spec.ts
+++ b/website/backend/api/crosslex/src/progress/progress.service.spec.ts
@@ -1,0 +1,213 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { ProgressService } from './progress.service';
+import type { PrismaService } from '../prisma/prisma.service';
+
+describe('ProgressService', () => {
+  let prisma: {
+    exercise: { findUnique: jest.Mock };
+    exerciseEvent: { create: jest.Mock };
+    wordProgress: { upsert: jest.Mock; findMany: jest.Mock };
+    $transaction: jest.Mock;
+  };
+  let service: ProgressService;
+
+  beforeEach(() => {
+    prisma = {
+      exercise: { findUnique: jest.fn() },
+      exerciseEvent: { create: jest.fn() },
+      wordProgress: { upsert: jest.fn(), findMany: jest.fn() },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+
+    service = new ProgressService(prisma as unknown as PrismaService);
+  });
+
+  describe('recordExerciseResult', () => {
+    it('rejects an unknown exerciseId before touching the transaction', async () => {
+      prisma.exercise.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.recordExerciseResult('user-1', {
+          exerciseId: 'fake-id',
+          correct: true,
+        }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('derives wordId and exerciseType from the Exercise row, not the input', async () => {
+      prisma.exercise.findUnique.mockResolvedValue({
+        id: 'exercise-1',
+        wordId: 'word-1',
+        exerciseType: 'wordDefinition',
+      });
+      prisma.exerciseEvent.create.mockResolvedValue({});
+      prisma.wordProgress.upsert.mockResolvedValue({
+        id: 'wp-1',
+        wordId: 'word-1',
+        seenCount: 1,
+        correctCount: 1,
+        lastSeenAt: new Date(),
+        word: { wordKey: 'auto' },
+      });
+
+      await service.recordExerciseResult('user-1', {
+        exerciseId: 'exercise-1',
+        correct: true,
+      });
+
+      const eventData = prisma.exerciseEvent.create.mock.calls[0][0].data;
+      expect(eventData).toMatchObject({
+        userId: 'user-1',
+        wordId: 'word-1',
+        exerciseId: 'exercise-1',
+        exerciseType: 'wordDefinition',
+        correct: true,
+      });
+    });
+
+    it('upserts WordProgress on the compound (userId, wordId) key, incrementing correctCount when correct', async () => {
+      prisma.exercise.findUnique.mockResolvedValue({
+        id: 'exercise-1',
+        wordId: 'word-1',
+        exerciseType: 'wordDefinition',
+      });
+      prisma.exerciseEvent.create.mockResolvedValue({});
+      prisma.wordProgress.upsert.mockResolvedValue({
+        id: 'wp-1',
+        wordId: 'word-1',
+        seenCount: 5,
+        correctCount: 5,
+        lastSeenAt: new Date(),
+        word: { wordKey: 'auto' },
+      });
+
+      await service.recordExerciseResult('user-1', {
+        exerciseId: 'exercise-1',
+        correct: true,
+      });
+
+      const upsertArgs = prisma.wordProgress.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({
+        userId_wordId: { userId: 'user-1', wordId: 'word-1' },
+      });
+      expect(upsertArgs.create).toEqual({
+        userId: 'user-1',
+        wordId: 'word-1',
+        seenCount: 1,
+        correctCount: 1,
+      });
+      expect(upsertArgs.update.seenCount).toEqual({ increment: 1 });
+      expect(upsertArgs.update.correctCount).toEqual({ increment: 1 });
+    });
+
+    it('omits correctCount from the update entirely on a wrong answer, rather than incrementing by zero', async () => {
+      prisma.exercise.findUnique.mockResolvedValue({
+        id: 'exercise-1',
+        wordId: 'word-1',
+        exerciseType: 'wordDefinition',
+      });
+      prisma.exerciseEvent.create.mockResolvedValue({});
+      prisma.wordProgress.upsert.mockResolvedValue({
+        id: 'wp-1',
+        wordId: 'word-1',
+        seenCount: 5,
+        correctCount: 2,
+        lastSeenAt: new Date(),
+        word: { wordKey: 'auto' },
+      });
+
+      await service.recordExerciseResult('user-1', {
+        exerciseId: 'exercise-1',
+        correct: false,
+      });
+
+      const upsertArgs = prisma.wordProgress.upsert.mock.calls[0][0];
+      expect(upsertArgs.create.correctCount).toBe(0);
+      expect(upsertArgs.update.correctCount).toBeUndefined();
+    });
+
+    it('flattens word.wordKey onto the returned WordProgress, not a raw Prisma row', async () => {
+      prisma.exercise.findUnique.mockResolvedValue({
+        id: 'exercise-1',
+        wordId: 'word-1',
+        exerciseType: 'wordDefinition',
+      });
+      prisma.exerciseEvent.create.mockResolvedValue({});
+      const lastSeenAt = new Date();
+      prisma.wordProgress.upsert.mockResolvedValue({
+        id: 'wp-1',
+        wordId: 'word-1',
+        seenCount: 1,
+        correctCount: 1,
+        lastSeenAt,
+        word: { wordKey: 'auto' },
+      });
+
+      const result = await service.recordExerciseResult('user-1', {
+        exerciseId: 'exercise-1',
+        correct: true,
+      });
+
+      expect(result).toEqual({
+        id: 'wp-1',
+        wordId: 'word-1',
+        wordKey: 'auto',
+        seenCount: 1,
+        correctCount: 1,
+        lastSeenAt,
+      });
+    });
+  });
+
+  describe('getMyProgress', () => {
+    it('scopes the query to the given userId and flattens wordKey for every row', async () => {
+      const lastSeenAt = new Date();
+      prisma.wordProgress.findMany.mockResolvedValue([
+        {
+          id: 'wp-1',
+          wordId: 'word-1',
+          seenCount: 3,
+          correctCount: 2,
+          lastSeenAt,
+          word: { wordKey: 'auto' },
+        },
+        {
+          id: 'wp-2',
+          wordId: 'word-2',
+          seenCount: 1,
+          correctCount: 1,
+          lastSeenAt,
+          word: { wordKey: 'katze' },
+        },
+      ]);
+
+      const result = await service.getMyProgress('user-1');
+
+      expect(prisma.wordProgress.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        include: { word: true },
+      });
+      expect(result).toEqual([
+        {
+          id: 'wp-1',
+          wordId: 'word-1',
+          wordKey: 'auto',
+          seenCount: 3,
+          correctCount: 2,
+          lastSeenAt,
+        },
+        {
+          id: 'wp-2',
+          wordId: 'word-2',
+          wordKey: 'katze',
+          seenCount: 1,
+          correctCount: 1,
+          lastSeenAt,
+        },
+      ]);
+    });
+  });
+});

--- a/website/backend/api/crosslex/src/progress/progress.service.ts
+++ b/website/backend/api/crosslex/src/progress/progress.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { RecordExerciseResultInput } from './dto/record-exercise-result.input';
+import { WordProgress } from './models/word-progress.model';
+
+@Injectable()
+export class ProgressService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async recordExerciseResult(
+    userId: string,
+    input: RecordExerciseResultInput,
+  ): Promise<WordProgress> {
+    const exercise = await this.prisma.exercise.findUnique({
+      where: { id: input.exerciseId },
+    });
+
+    if (!exercise) {
+      throw new NotFoundException('Exercise not found');
+    }
+
+    const [, wordProgress] = await this.prisma.$transaction([
+      this.prisma.exerciseEvent.create({
+        data: {
+          userId,
+          wordId: exercise.wordId,
+          exerciseId: exercise.id,
+          exerciseType: exercise.exerciseType,
+          correct: input.correct,
+        },
+      }),
+      this.prisma.wordProgress.upsert({
+        where: { userId_wordId: { userId, wordId: exercise.wordId } },
+        create: {
+          userId,
+          wordId: exercise.wordId,
+          seenCount: 1,
+          correctCount: input.correct ? 1 : 0,
+        },
+        update: {
+          seenCount: { increment: 1 },
+          correctCount: input.correct ? { increment: 1 } : undefined,
+        },
+        include: { word: true },
+      }),
+    ]);
+
+    return {
+      id: wordProgress.id,
+      wordId: wordProgress.wordId,
+      wordKey: wordProgress.word.wordKey,
+      seenCount: wordProgress.seenCount,
+      correctCount: wordProgress.correctCount,
+      lastSeenAt: wordProgress.lastSeenAt,
+    };
+  }
+
+  async getMyProgress(userId: string): Promise<Array<WordProgress>> {
+    const rows = await this.prisma.wordProgress.findMany({
+      where: { userId },
+      include: { word: true },
+    });
+
+    return rows.map(row => ({
+      id: row.id,
+      wordId: row.wordId,
+      wordKey: row.word.wordKey,
+      seenCount: row.seenCount,
+      correctCount: row.correctCount,
+      lastSeenAt: row.lastSeenAt,
+    }));
+  }
+}

--- a/website/backend/api/crosslex/test/auth.e2e-spec.ts
+++ b/website/backend/api/crosslex/test/auth.e2e-spec.ts
@@ -6,6 +6,7 @@ import request from 'supertest';
 
 import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/prisma/prisma.service';
+import { resetDatabase } from './reset-database';
 
 // Boots the real app (real GraphQL layer, real JwtService/argon2/cookie
 // logic) against the dedicated `test` Postgres schema — see
@@ -42,9 +43,7 @@ describe('Auth (e2e)', () => {
   });
 
   beforeEach(async () => {
-    // FK order: RefreshToken references User.
-    await prisma.refreshToken.deleteMany();
-    await prisma.user.deleteMany();
+    await resetDatabase(prisma);
   });
 
   function gql(query: string, variables?: Record<string, unknown>) {

--- a/website/backend/api/crosslex/test/progress.e2e-spec.ts
+++ b/website/backend/api/crosslex/test/progress.e2e-spec.ts
@@ -1,0 +1,230 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { resetDatabase } from './reset-database';
+
+// Same boot pattern as auth.e2e-spec.ts — real app, real GraphQL layer,
+// real Postgres via the dedicated `test` schema. This is also the first
+// place JwtAuthGuard/@CurrentUser() are ever exercised against a real
+// request; nothing else in the app uses them yet.
+describe('Progress (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+
+    prisma = moduleRef.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase(prisma);
+  });
+
+  function gql(query: string, variables?: Record<string, unknown>) {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({ query, variables });
+  }
+
+  function gqlWithAuth(
+    query: string,
+    accessToken: string,
+    variables?: Record<string, unknown>,
+  ) {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ query, variables });
+  }
+
+  const SIGNUP = `
+    mutation Signup($input: SignupInput!) {
+      signup(input: $input) { accessToken }
+    }
+  `;
+  const RECORD_EXERCISE_RESULT = `
+    mutation RecordExerciseResult($input: RecordExerciseResultInput!) {
+      recordExerciseResult(input: $input) {
+        id
+        wordId
+        wordKey
+        seenCount
+        correctCount
+      }
+    }
+  `;
+  const MY_PROGRESS = `
+    query MyProgress {
+      myProgress {
+        id
+        wordId
+        wordKey
+        seenCount
+        correctCount
+      }
+    }
+  `;
+
+  async function signupAndGetAccessToken(
+    email: string,
+    password = 'correct horse battery staple',
+  ): Promise<string> {
+    const res = await gql(SIGNUP, { input: { email, password } });
+    return res.body.data.signup.accessToken;
+  }
+
+  // No content-authoring API exists yet — seed directly via Prisma, the
+  // same way the content pipeline (mock/data) would eventually populate
+  // these tables. Returns the exerciseId the tests actually need.
+  async function seedWordAndExercise(wordKey: string): Promise<string> {
+    const word = await prisma.word.create({ data: { wordKey } });
+    const exercise = await prisma.exercise.create({
+      data: {
+        wordId: word.id,
+        exerciseType: 'wordDefinition',
+        content: {},
+      },
+    });
+    return exercise.id;
+  }
+
+  describe('authorization', () => {
+    it('rejects recordExerciseResult with no token', async () => {
+      const exerciseId = await seedWordAndExercise('auto');
+
+      const res = await gql(RECORD_EXERCISE_RESULT, {
+        input: { exerciseId, correct: true },
+      });
+
+      expect(res.body.data?.recordExerciseResult ?? null).toBeNull();
+      expect(res.body.errors).toBeDefined();
+    });
+
+    it('rejects myProgress with no token', async () => {
+      const res = await gql(MY_PROGRESS);
+
+      expect(res.body.data?.myProgress ?? null).toBeNull();
+      expect(res.body.errors).toBeDefined();
+    });
+  });
+
+  describe('recordExerciseResult', () => {
+    it('rejects an unknown exerciseId', async () => {
+      const accessToken = await signupAndGetAccessToken('unknown@user.com');
+
+      const res = await gqlWithAuth(RECORD_EXERCISE_RESULT, accessToken, {
+        input: { exerciseId: '00000000-0000-0000-0000-000000000000', correct: true },
+      });
+
+      expect(res.body.data?.recordExerciseResult ?? null).toBeNull();
+      expect(res.body.errors[0].message).toBe('Exercise not found');
+    });
+
+    it('creates a WordProgress row on the first attempt', async () => {
+      const accessToken = await signupAndGetAccessToken('first@user.com');
+      const exerciseId = await seedWordAndExercise('auto');
+
+      const res = await gqlWithAuth(RECORD_EXERCISE_RESULT, accessToken, {
+        input: { exerciseId, correct: true },
+      });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.recordExerciseResult).toMatchObject({
+        wordKey: 'auto',
+        seenCount: 1,
+        correctCount: 1,
+      });
+    });
+
+    it('upserts idempotently: a second attempt increments the same row, not a duplicate', async () => {
+      const accessToken = await signupAndGetAccessToken('second@user.com');
+      const exerciseId = await seedWordAndExercise('auto');
+
+      await gqlWithAuth(RECORD_EXERCISE_RESULT, accessToken, {
+        input: { exerciseId, correct: true },
+      });
+      const secondRes = await gqlWithAuth(RECORD_EXERCISE_RESULT, accessToken, {
+        input: { exerciseId, correct: false },
+      });
+
+      expect(secondRes.body.data.recordExerciseResult).toMatchObject({
+        wordKey: 'auto',
+        seenCount: 2,
+        // Stayed at 1 — the wrong second attempt must not increment it.
+        correctCount: 1,
+      });
+
+      const progressRes = await gqlWithAuth(MY_PROGRESS, accessToken);
+      expect(progressRes.body.data.myProgress).toHaveLength(1);
+    });
+  });
+
+  describe('myProgress — the negative test: user B cannot see user A data', () => {
+    it('returns only the calling users own rows, never another users, even after that user has real data', async () => {
+      const tokenA = await signupAndGetAccessToken('user-a@user.com');
+      const tokenB = await signupAndGetAccessToken('user-b@user.com');
+      const exerciseId = await seedWordAndExercise('auto');
+
+      // A does real work. B has done nothing.
+      await gqlWithAuth(RECORD_EXERCISE_RESULT, tokenA, {
+        input: { exerciseId, correct: true },
+      });
+
+      const bProgress = await gqlWithAuth(MY_PROGRESS, tokenB);
+      expect(bProgress.body.data.myProgress).toEqual([]);
+
+      const aProgress = await gqlWithAuth(MY_PROGRESS, tokenA);
+      expect(aProgress.body.data.myProgress).toHaveLength(1);
+    });
+
+    it('keeps each users progress on the same word fully independent', async () => {
+      const tokenA = await signupAndGetAccessToken('indep-a@user.com');
+      const tokenB = await signupAndGetAccessToken('indep-b@user.com');
+      const exerciseId = await seedWordAndExercise('katze');
+
+      // Both attempt the same word, different outcomes.
+      await gqlWithAuth(RECORD_EXERCISE_RESULT, tokenA, {
+        input: { exerciseId, correct: true },
+      });
+      await gqlWithAuth(RECORD_EXERCISE_RESULT, tokenB, {
+        input: { exerciseId, correct: false },
+      });
+      await gqlWithAuth(RECORD_EXERCISE_RESULT, tokenB, {
+        input: { exerciseId, correct: false },
+      });
+
+      const aProgress = await gqlWithAuth(MY_PROGRESS, tokenA);
+      const bProgress = await gqlWithAuth(MY_PROGRESS, tokenB);
+
+      expect(aProgress.body.data.myProgress).toEqual([
+        expect.objectContaining({ wordKey: 'katze', seenCount: 1, correctCount: 1 }),
+      ]);
+      expect(bProgress.body.data.myProgress).toEqual([
+        expect.objectContaining({ wordKey: 'katze', seenCount: 2, correctCount: 0 }),
+      ]);
+    });
+  });
+});

--- a/website/backend/api/crosslex/test/reset-database.ts
+++ b/website/backend/api/crosslex/test/reset-database.ts
@@ -1,0 +1,25 @@
+import { PrismaService } from '../src/prisma/prisma.service';
+
+// Every e2e spec's beforeEach should call this — not just delete the
+// tables that one file happens to care about. All e2e specs share one
+// real Postgres `test` schema across the whole run (each file boots its
+// own app, but not its own database), so a spec that only knows about its
+// own tables will hit FK-constraint failures on another file's leftover
+// data. One shared, FK-ordered reset keeps every spec file in sync
+// automatically as new tables get added, instead of N copies of this list
+// silently drifting out of date.
+//
+// This alone isn't sufficient once there's more than one e2e spec file,
+// though: Jest runs different spec *files* in parallel worker processes by
+// default, and since they share this one real database, one file's
+// beforeEach can wipe rows out from under another file's in-flight test.
+// That's why test:e2e passes --runInBand — forces every e2e file to run
+// serially, so only one file's reset cycle is ever active at a time.
+export async function resetDatabase(prisma: PrismaService): Promise<void> {
+  await prisma.exerciseEvent.deleteMany();
+  await prisma.wordProgress.deleteMany();
+  await prisma.exercise.deleteMany();
+  await prisma.word.deleteMany();
+  await prisma.refreshToken.deleteMany();
+  await prisma.user.deleteMany();
+}

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -5594,7 +5594,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/schematics@npm:^11.0.1":
+"@nestjs/schematics@npm:^11.0.1, @nestjs/schematics@npm:^11.1.0":
   version: 11.1.0
   resolution: "@nestjs/schematics@npm:11.1.0"
   dependencies:
@@ -10694,6 +10694,7 @@ __metadata:
     "@nestjs/jwt": "npm:^11.0.2"
     "@nestjs/passport": "npm:^11.0.5"
     "@nestjs/platform-express": "npm:^11.1.0"
+    "@nestjs/schematics": "npm:^11.1.0"
     "@nestjs/testing": "npm:^11.1.0"
     "@prisma/adapter-pg": "npm:^7.9.0"
     "@prisma/client": "npm:^7.9.0"


### PR DESCRIPTION
## Summary
- Word/WordProgress/Exercise/ExerciseEvent schema — Word uses a surrogate UUID id (not wordKey) since German has real homographs no natural key can disambiguate; Exercise content is JSON + a type discriminator to avoid schema migrations for content-only changes
- `recordExerciseResult`/`myProgress` — first resolvers to actually apply `JwtAuthGuard`; `userId` only ever from `@CurrentUser()`, ownership enforced in the service layer's `where` clauses, never a GraphQL argument
- Real two-account negative e2e test proving user B cannot see user A's data against a real Postgres instance
- Fixes a real cross-file e2e test-isolation bug surfaced by adding a second e2e spec file (parallel Jest workers + one shared real DB = races) — shared `resetDatabase()` helper + `--runInBand`
- Starts `DECISIONS.md` — architectural decisions and reasoning, meant to be appended to going forward

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — 34 unit tests pass
- [x] `yarn test:e2e` — 20 e2e tests pass (stable across repeated runs)