### PR TITLE
feat: local Docker infra + CORS allowlist (Phase 6, local-only)

### DIFF
--- a/website/.dockerignore
+++ b/website/.dockerignore
@@ -1,0 +1,18 @@
+# Reinstalled fresh inside the container — argon2/Prisma both involve
+# native binaries, so a host-installed node_modules (built for macOS)
+# would silently break if it ever ended up in an image built for Linux.
+**/node_modules
+
+**/dist
+**/.next
+**/build
+**/coverage
+
+.git
+.yarn/cache
+.yarn/install-state.gz
+
+**/*.pem
+.env
+.env.*
+!.env.example

--- a/website/.env.example
+++ b/website/.env.example
@@ -12,3 +12,6 @@ JWT_PUBLIC_KEY_PATH=
 JWT_ACCESS_TOKEN_TTL=
 REFRESH_TOKEN_TTL_DAYS=
 COOKIE_DOMAIN=crosslex.local
+# Comma-separated. Only the local frontend origin for now — stage/prod
+# values deliberately not decided yet (depends on real deployment, Phase 5).
+CORS_ALLOWED_ORIGINS=http://app.crosslex.local:5173

--- a/website/backend/api/crosslex/Dockerfile
+++ b/website/backend/api/crosslex/Dockerfile
@@ -1,0 +1,50 @@
+# Build context must be website/ (the Yarn workspace root), not this
+# directory — Yarn needs every workspace's package.json present to resolve
+# the lockfile correctly. See docker-compose.yml's `build.context`.
+
+FROM node:22-slim AS build
+WORKDIR /workspace
+RUN corepack enable
+# node:22-slim has no OpenSSL — Prisma's CLI needs it to detect which
+# engine build to use, and silently falls back to guessing without it.
+RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+
+# Full monorepo source (node_modules/dist/.git excluded via .dockerignore).
+# Installing every workspace's deps here, not just this package's, is a
+# deliberate simplification — this image is for local dev/test infra, not
+# a size-optimized deploy artifact. Revisit with Yarn's `focus` or a
+# Turborepo-style prune if/when this becomes a real deploy image.
+COPY . .
+RUN yarn install --immutable
+
+WORKDIR /workspace/backend/api/crosslex
+# `prisma migrate dev`/`db push` don't auto-run `generate` in this Prisma
+# version — the generated client has to exist before `nest build` compiles
+# src/, since PrismaService imports from it directly.
+RUN npx prisma generate
+RUN yarn build
+
+FROM node:22-slim AS runtime
+WORKDIR /workspace
+RUN corepack enable
+# Same reason as the build stage — `prisma migrate deploy` runs here too.
+RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+
+# node_modules is hoisted across the workspace by Yarn's node-modules
+# linker, so both the root and the package's own node_modules are needed.
+COPY --from=build /workspace/node_modules ./node_modules
+COPY --from=build /workspace/backend/api/crosslex/node_modules ./backend/api/crosslex/node_modules
+COPY --from=build /workspace/backend/api/crosslex/dist ./backend/api/crosslex/dist
+COPY --from=build /workspace/backend/api/crosslex/package.json ./backend/api/crosslex/package.json
+# prisma/ (schema + migrations) is needed at runtime too — the container
+# runs `prisma migrate deploy` before starting the server, not just the
+# already-generated client.
+COPY --from=build /workspace/backend/api/crosslex/prisma ./backend/api/crosslex/prisma
+COPY --from=build /workspace/backend/api/crosslex/prisma.config.ts ./backend/api/crosslex/prisma.config.ts
+
+WORKDIR /workspace/backend/api/crosslex
+EXPOSE 4000
+# Migrate then start — keeps `docker compose up` a genuine one-command
+# path to a working server against a fresh Postgres volume, no manual
+# migrate step required first.
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/main.js"]

--- a/website/backend/api/crosslex/docker-compose.yml
+++ b/website/backend/api/crosslex/docker-compose.yml
@@ -16,5 +16,40 @@ services:
       timeout: 3s
       retries: 5
 
+  # Runs the actual NestJS API in a container, for testing via
+  # Postman/curl without needing `yarn dev` on the host — and the basis
+  # for later local-infra work, once other backend pieces exist to run
+  # alongside it. `yarn db` (just postgres) is unaffected; this is opt-in
+  # via `yarn docker:up` or `docker compose up`.
+  api:
+    build:
+      context: ../../..
+      dockerfile: backend/api/crosslex/Dockerfile
+    container_name: crosslex-api
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - '4000:4000'
+    environment:
+      PORT: '4000'
+      # postgres, not localhost — inside the compose network, the DB is
+      # reachable by service name, not the host loopback address the
+      # locally-run (non-Docker) app uses.
+      DATABASE_URL: 'postgresql://crosslex:crosslex@postgres:5432/crosslex?schema=public'
+      JWT_KEY_SOURCE: file
+      JWT_PRIVATE_KEY_PATH: /keys/private.pem
+      JWT_PUBLIC_KEY_PATH: /keys/public.pem
+      JWT_ACCESS_TOKEN_TTL: 15m
+      REFRESH_TOKEN_TTL_DAYS: '30'
+      COOKIE_DOMAIN: crosslex.local
+      CORS_ALLOWED_ORIGINS: http://app.crosslex.local:5173
+    volumes:
+      # Keys stay out of the image (see .dockerignore) — mounted in at
+      # runtime instead, read-only. Plain PEM text files, so no
+      # macOS-vs-Linux native-binary concern here, unlike node_modules.
+      - ./private.pem:/keys/private.pem:ro
+      - ./public.pem:/keys/public.pem:ro
+
 volumes:
   crosslex-pg-data:

--- a/website/backend/api/crosslex/package.json
+++ b/website/backend/api/crosslex/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "db": "docker compose up -d",
+    "db": "docker compose up -d postgres",
+    "docker:up": "docker compose up --build",
     "down": "docker compose down",
     "wipe": "docker volume rm crosslex_crosslex-pg-data",
     "dev": "nest start --watch",

--- a/website/backend/api/crosslex/src/cors.config.ts
+++ b/website/backend/api/crosslex/src/cors.config.ts
@@ -1,0 +1,21 @@
+import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+
+// Shared by main.ts and every e2e spec's test app bootstrap — one place
+// for this logic, not N copies that can silently drift apart (exactly
+// what happened before test/reset-database.ts existed).
+export function getCorsOptions(): CorsOptions {
+  return {
+    // Comma-separated allowlist, empty/unset means no cross-origin browser
+    // requests are allowed — a safe default, not a crash, unlike
+    // DATABASE_URL/JWT_KEY_SOURCE. Only local values exist today; stage/prod
+    // are deliberately not decided yet (depends on real deployment).
+    origin: (process.env.CORS_ALLOWED_ORIGINS ?? '')
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+    // Required for the httpOnly refresh cookie to actually be sent/stored
+    // cross-origin — without this, the browser won't include credentials
+    // on the request or accept the Set-Cookie response.
+    credentials: true,
+  };
+}

--- a/website/backend/api/crosslex/src/main.ts
+++ b/website/backend/api/crosslex/src/main.ts
@@ -3,10 +3,12 @@ import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
 
 import { AppModule } from './app.module';
+import { getCorsOptions } from './cors.config';
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
+  app.enableCors(getCorsOptions());
   app.useGlobalPipes(
     new ValidationPipe({
       // Runs class-transformer (so @Transform decorators actually fire)

--- a/website/backend/api/crosslex/test/auth.e2e-spec.ts
+++ b/website/backend/api/crosslex/test/auth.e2e-spec.ts
@@ -6,6 +6,7 @@ import request from 'supertest';
 
 import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/prisma/prisma.service';
+import { getCorsOptions } from '../src/cors.config';
 import { resetDatabase } from './reset-database';
 
 // Boots the real app (real GraphQL layer, real JwtService/argon2/cookie
@@ -25,6 +26,7 @@ describe('Auth (e2e)', () => {
     // Mirrors main.ts exactly — these tests would be meaningless if they
     // exercised different middleware/pipes than what actually runs.
     app.use(cookieParser());
+    app.enableCors(getCorsOptions());
     app.useGlobalPipes(
       new ValidationPipe({
         transform: true,

--- a/website/backend/api/crosslex/test/progress.e2e-spec.ts
+++ b/website/backend/api/crosslex/test/progress.e2e-spec.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 
 import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/prisma/prisma.service';
+import { getCorsOptions } from '../src/cors.config';
 import { resetDatabase } from './reset-database';
 
 // Same boot pattern as auth.e2e-spec.ts — real app, real GraphQL layer,
@@ -22,6 +23,7 @@ describe('Progress (e2e)', () => {
 
     app = moduleRef.createNestApplication();
     app.use(cookieParser());
+    app.enableCors(getCorsOptions());
     app.useGlobalPipes(
       new ValidationPipe({
         transform: true,


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile + docker-compose `api` service — the whole backend (Postgres + API) runnable locally with one command, for Postman/curl testing without `yarn dev`, and the basis for later local-infra work
- `app.enableCors()` with an env-driven, credentials-aware origin allowlist — required for the httpOnly refresh cookie to work cross-origin between `app.crosslex.local`/`api.crosslex.local`. Local origin only; stage/prod deliberately undecided pending real deployment (Phase 5)
- Shared `getCorsOptions()` used by `main.ts` and both e2e specs, avoiding the kind of duplicated-setup drift that `test/reset-database.ts` had to fix earlier
- Verified against the real containerized server (not just tests): allowed origin gets `Access-Control-Allow-Origin` echoed back, disallowed origin doesn't, response body identical either way

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — 34 unit tests pass
- [x] `yarn test:e2e` — 20 e2e tests pass
- [x] `docker compose up --build` — real signup/login/myProgress calls verified end-to-end through the container
- [x] Real curl verification of CORS headers for both an allowed and disallowed origin